### PR TITLE
feat: add PyPI downloads, uv, and Ruff badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ A Python client for the ApiHub service that provides a clean, Pythonic interface
 [![Python Version](https://img.shields.io/badge/python-3.12+-blue.svg)](https://python.org)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](https://github.com/Zipstack/apihub-python-client)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/apihub-python-client)](https://pypi.org/project/apihub-python-client/)
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 ## 🚀 Features
 


### PR DESCRIPTION
## Summary

This PR adds three new badges to the README to improve project visibility and showcase modern development practices.

## Changes

- **PyPI Downloads Badge**: Displays monthly download statistics from PyPI
- **uv Badge**: Highlights the use of uv for fast Python package management  
- **Ruff Badge**: Showcases code quality tooling with Ruff for linting and formatting

## Motivation

Adding these badges helps:
- **Showcase package popularity** through PyPI download metrics
- **Highlight modern tooling** being used in the project (uv + Ruff)
- **Improve project credibility** and demonstrate commitment to code quality
- **Increase visibility** for potential users and contributors

## Related Issues

N/A - This is an enhancement to improve project presentation.

## Testing

- ✅ Pre-commit hooks passed (prettier, file checks)
- ✅ No breaking changes to existing functionality
- ✅ Badges display correctly in GitHub markdown

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (README badges)
- [x] No breaking changes introduced
- [x] Pre-commit hooks pass
- [x] Badges are properly formatted and functional

## Screenshots

The new badges will appear after the existing Python version, License, and Build Status badges:

```
[![PyPI Downloads](https://img.shields.io/pypi/dm/apihub-python-client)](https://pypi.org/project/apihub-python-client/)
[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
```