### PR TITLE
docs: Add version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Python client for the Unstract ApiHub service that provides a clean, Pythonic interface for document processing APIs following the extract → status → retrieve pattern.
 
 [![Python Version](https://img.shields.io/badge/python-3.12+-blue.svg)](https://python.org)
-[![Version](https://img.shields.io/badge/version-0.1.1-blue.svg)](https://pypi.org/project/apihub-python-client/)
+[![PyPI Version](https://img.shields.io/pypi/v/apihub-python-client)](https://pypi.org/project/apihub-python-client/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](https://github.com/Zipstack/apihub-python-client)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/apihub-python-client)](https://pypi.org/project/apihub-python-client/)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A Python client for the Unstract ApiHub service that provides a clean, Pythonic interface for document processing APIs following the extract → status → retrieve pattern.
 
 [![Python Version](https://img.shields.io/badge/python-3.12+-blue.svg)](https://python.org)
+[![Version](https://img.shields.io/badge/version-0.1.1-blue.svg)](https://pypi.org/project/apihub-python-client/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](https://github.com/Zipstack/apihub-python-client)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/apihub-python-client)](https://pypi.org/project/apihub-python-client/)


### PR DESCRIPTION
## Summary

This PR adds a version badge to the README.md file to display the current client version (v0.1.1) alongside the other project badges.

## Changes

- Added version badge displaying current client version (0.1.1)
- Badge links to the PyPI package page for easy access to package information
- Positioned the badge after the Python version badge for logical grouping and better visual flow

## Motivation

Having a version badge in the README provides:
- Immediate visibility of the current package version
- Quick access to the PyPI package page
- Better project documentation and transparency
- Consistency with common open-source project practices

## Related Issues

N/A - This is a documentation enhancement.

## Testing

- ✅ All pre-commit hooks passed (prettier for markdown formatting)
- ✅ Badge renders correctly in markdown
- ✅ Link to PyPI package page is functional
- ✅ No functional changes - only documentation update

## Checklist

- [x] Documentation follows project standards
- [x] Badge URL and version are accurate
- [x] Badge placement is logical and visually appealing
- [x] No breaking changes introduced
- [x] Self-review completed